### PR TITLE
Ensure window.cordova.plugins so $ionicPlatform.ready handler succeeds.

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -13,7 +13,7 @@ angular.module('starter', ['ionic', 'starter.controllers'])
                 $ionicPlatform.ready(function () {
                     // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
                     // for form inputs)
-                    if (window.cordova && window.cordova.plugins.Keyboard) {
+                    if (window.cordova && window.cordova.plugins && window.cordova.plugins.Keyboard) {
                         cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true);
                     }
                     if (window.StatusBar) {


### PR DESCRIPTION
Running under ios with no plugins installed caused a crash here which prevented the ready handler from executing properly: as a result, later calls to download() failed with an Error "deviceready has not fired after 5 seconds".  Adding the extra check here allows the ready handler to succeed, fixing this problem.
